### PR TITLE
Add ability to create polymorphic selects for polymorphic belongs to relationships.

### DIFF
--- a/lib/rails_polymorphic_select.rb
+++ b/lib/rails_polymorphic_select.rb
@@ -1,4 +1,6 @@
 require "rails_polymorphic_select/engine"
 
 module RailsPolymorphicSelect
+  autoload :FormBuilder, 'rails_polymorphic_select/form_builder'
+  autoload :BelongsToBuilderExtension, 'rails_polymorphic_select/belongs_to_builder_extension'
 end

--- a/lib/rails_polymorphic_select/belongs_to_builder_extension.rb
+++ b/lib/rails_polymorphic_select/belongs_to_builder_extension.rb
@@ -1,0 +1,25 @@
+module RailsPolymorphicSelect
+  module BelongsToBuilderExtension
+    def define_accessors(mixin, reflection)
+      super
+
+      if reflection.options[:polymorphic]
+        define_global_id_methods(mixin, reflection.name)
+      end
+    end
+
+    def define_global_id_methods(mixin, name)
+      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def #{name}_global_id
+          #{name}.try(:to_global_id)
+        end
+
+        def #{name}_global_id=(new_global_id)
+          self.#{name} = if new_global_id.present?
+            GlobalID::Locator.locate(new_global_id)
+          end
+        end
+      CODE
+    end
+  end
+end

--- a/lib/rails_polymorphic_select/engine.rb
+++ b/lib/rails_polymorphic_select/engine.rb
@@ -8,5 +8,9 @@ module RailsPolymorphicSelect
       g.helper false
     end
 
+    initializer "rails_polymorphic_select.include_extensions" do |app|
+      ActionView::Helpers::FormBuilder.send(:include, RailsPolymorphicSelect::FormBuilder)
+      ActiveRecord::Associations::Builder::BelongsTo.extend RailsPolymorphicSelect::BelongsToBuilderExtension
+    end
   end
 end

--- a/lib/rails_polymorphic_select/form_builder.rb
+++ b/lib/rails_polymorphic_select/form_builder.rb
@@ -1,0 +1,36 @@
+module RailsPolymorphicSelect
+  module FormBuilder
+    LABEL_NAME_METHODS = [
+      :to_label,
+      :display_name,
+      :label,
+      :name,
+      :title,
+      :username,
+      :login,
+      :value,
+      :to_s
+    ]
+
+    def polymorphic_select(method_name, models, options = {}, html_options = {})
+      label_method = options.delete(:label_method)
+
+      choices = models.map do |model_class|
+        [model_class.model_name.human, model_class.all.map { |record|
+          [label_for(record, label_method), record.to_global_id]
+        }]
+      end
+
+      select(method_name, choices, options, html_options)
+    end
+
+    private
+
+    def label_for(record, label_method)
+      unless label_method && record.respond_to?(label_method)
+        label_method = LABEL_NAME_METHODS.detect{|method_name| record.respond_to?(method_name) }
+      end
+      record.send(label_method)
+    end
+  end
+end

--- a/spec/belongs_to_builder_extension_spec.rb
+++ b/spec/belongs_to_builder_extension_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe RailsPolymorphicSelect::BelongsToBuilderExtension do
+  let(:zebra){ create(:animal, name: 'Zebra', scientific_name: 'Equus zebra') }
+  let(:cheetah){ create(:animal, eats: zebra)}
+
+  it 'creates a global id reader method for polymorphic belongs to relationships' do
+    expect(Animal.public_method_defined?(:eats_global_id)).to eql(true)
+  end
+
+  it 'creates a global id writer method for polymorphic belongs to relationships' do
+    expect(Animal.public_method_defined?(:eats_global_id=)).to eql(true)
+  end
+
+  it 'does not create a global id reader method for non-polymorphic belongs to relationships' do
+    expect(Planet.public_method_defined?(:star_global_id)).to eql(false)
+  end
+
+  it 'does not create a global id writer method for non-polymorphic belongs to relationships' do
+    expect(Planet.public_method_defined?(:star_global_id=)).to eql(false)
+  end
+
+  describe "#*_global_id" do
+    it "returns the related item's global id" do
+      expect(cheetah.eats_global_id).to eql(zebra.to_global_id)
+    end
+
+    it "returns nil if the relationship is not set" do
+      expect(zebra.eats_global_id).to be_nil
+    end
+  end
+
+  describe "#*_global_id=" do
+    it "relates the correct record" do
+      plant = create(:plant)
+      zebra.eats_global_id = plant.to_global_id
+      expect(zebra.eats).to eql(plant)
+    end
+
+    it "remove the relationship if the value is blank" do
+      cheetah.eats_global_id = ""
+      expect(cheetah.eats).to be_nil
+    end
+  end
+
+end

--- a/spec/dummy/app/models/animal.rb
+++ b/spec/dummy/app/models/animal.rb
@@ -1,0 +1,5 @@
+class Animal < ActiveRecord::Base
+  belongs_to :eats, polymorphic: true
+
+  validates :name, :scientific_name, presence: true
+end

--- a/spec/dummy/app/models/planet.rb
+++ b/spec/dummy/app/models/planet.rb
@@ -1,0 +1,5 @@
+class Planet < ActiveRecord::Base
+  belongs_to :star
+
+  validates :name, :star, presence: true
+end

--- a/spec/dummy/app/models/plant.rb
+++ b/spec/dummy/app/models/plant.rb
@@ -1,0 +1,3 @@
+class Plant < ActiveRecord::Base
+  validates :name, :scientific_name, presence: true
+end

--- a/spec/dummy/app/models/star.rb
+++ b/spec/dummy/app/models/star.rb
@@ -1,0 +1,3 @@
+class Star < ActiveRecord::Base
+  validates :name, presence: true
+end

--- a/spec/dummy/db/migrate/20150911212009_create_animals.rb
+++ b/spec/dummy/db/migrate/20150911212009_create_animals.rb
@@ -1,0 +1,12 @@
+class CreateAnimals < ActiveRecord::Migration
+  def change
+    create_table :animals do |t|
+      t.string :name, null: false
+      t.string :scientific_name, null: false
+
+      t.references :eats, polymorphic: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20150911212401_create_plants.rb
+++ b/spec/dummy/db/migrate/20150911212401_create_plants.rb
@@ -1,0 +1,10 @@
+class CreatePlants < ActiveRecord::Migration
+  def change
+    create_table :plants do |t|
+      t.string :name, null: false
+      t.string :scientific_name, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20150912014900_create_stars.rb
+++ b/spec/dummy/db/migrate/20150912014900_create_stars.rb
@@ -1,0 +1,8 @@
+class CreateStars < ActiveRecord::Migration
+  def change
+    create_table :stars do |t|
+      t.string :name, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20150912015008_create_planets.rb
+++ b/spec/dummy/db/migrate/20150912015008_create_planets.rb
@@ -1,0 +1,9 @@
+class CreatePlanets < ActiveRecord::Migration
+  def change
+    create_table :planets do |t|
+      t.string :name, null: false
+      t.references :stars, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,0 +1,45 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150912015008) do
+
+  create_table "animals", force: :cascade do |t|
+    t.string   "name",            null: false
+    t.string   "scientific_name", null: false
+    t.integer  "eats_id"
+    t.string   "eats_type"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  create_table "planets", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.integer  "stars_id",   null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "plants", force: :cascade do |t|
+    t.string   "name",            null: false
+    t.string   "scientific_name", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  create_table "stars", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/factories/animals.rb
+++ b/spec/factories/animals.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :animal do
+    name "Cheetah"
+    scientific_name "Acinonyx jubatus"
+  end
+end

--- a/spec/factories/planets.rb
+++ b/spec/factories/planets.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :planet do
+    name "Saturn"
+    star
+  end
+end

--- a/spec/factories/plants.rb
+++ b/spec/factories/plants.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :plant do
+    name "Fine Thatching Grass"
+    scientific_name "Hyparrhenia filipendula"
+  end
+end

--- a/spec/factories/stars.rb
+++ b/spec/factories/stars.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :star do
+    name "Altair"
+  end
+end

--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe RailsPolymorphicSelect::FormBuilder do
+  let!(:cheetah){ create(:animal) }
+  let!(:zebra){ create(:animal, name: 'Zebra', scientific_name: 'Equus zebra') }
+  let!(:plant){ create(:plant) }
+
+  let(:template){ ActionView::Base.new }
+
+  let(:form_builder){ ActionView::Helpers::FormBuilder.new(:animal, cheetah, template, {}) }
+
+
+  describe '#polymorphic_select' do
+    subject { form_builder.polymorphic_select(:eats_global_id, [Animal, Plant]) }
+
+    it "produces the correct markup" do
+      expect(subject).to have_tag('select', with: {name: 'animal[eats_global_id]'}) do
+        with_tag('optgroup', with: {label: 'Animal'}) do
+          with_tag('option', with: {value: cheetah.to_global_id}, text: cheetah.name)
+          with_tag('option', with: {value: zebra.to_global_id}, text: "Zebra")
+        end
+        with_tag('optgroup', with: {label: 'Plant'}) do
+          with_tag('option', with: {value: plant.to_global_id}, text: plant.name)
+        end
+      end
+    end
+
+    it "has no selected option if there is no resource selected yet" do
+      expect(subject).to_not have_tag('option', with: {selected: 'selected'})
+    end
+
+    describe 'explicitly setting the label method' do
+      subject { form_builder.polymorphic_select(:eats_global_id, [Animal, Plant], label_method: :scientific_name) }
+
+      it "produces the correct markup" do
+        expect(subject).to have_tag('select', with: {name: 'animal[eats_global_id]'}) do
+          with_tag('optgroup', with: {label: 'Animal'}) do
+            with_tag('option', with: {value: cheetah.to_global_id}, text: cheetah.scientific_name)
+            with_tag('option', with: {value: zebra.to_global_id}, text: "Equus zebra")
+          end
+          with_tag('optgroup', with: {label: 'Plant'}) do
+            with_tag('option', with: {value: plant.to_global_id}, text: plant.scientific_name)
+          end
+        end
+      end
+    end
+
+    describe 'using a #to_label method to override the autoguess of name' do
+      before do
+        Animal.send(:define_method, :to_label) do
+          scientific_name
+        end
+      end
+
+      it "produces the correct markup" do
+        expect(subject).to have_tag('select', with: {name: 'animal[eats_global_id]'}) do
+          with_tag('optgroup', with: {label: 'Animal'}) do
+            with_tag('option', with: {value: cheetah.to_global_id}, text: cheetah.scientific_name)
+            with_tag('option', with: {value: zebra.to_global_id}, text: "Equus zebra")
+          end
+          with_tag('optgroup', with: {label: 'Plant'}) do
+            with_tag('option', with: {value: plant.to_global_id}, text: plant.name)
+          end
+        end
+      end
+    end
+
+    describe 'with an item selected' do
+      before do
+        cheetah.update_attributes(eats: zebra)
+      end
+
+      it "selects the correct item" do
+        expect(subject).to have_tag('option', with: {value: zebra.to_global_id, selected: 'selected'})
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,7 +54,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  # config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:


### PR DESCRIPTION
- Create global_id instance methods for polymorphic relationships
- Add `polymorphic_select` method to the `FormBuilder`
